### PR TITLE
Semaphore acquire deadlock & timeout handling fixed

### DIFF
--- a/src/test/java/com/github/topikachu/jenkins/concurrent/semaphore/SemaphoreTest.java
+++ b/src/test/java/com/github/topikachu/jenkins/concurrent/semaphore/SemaphoreTest.java
@@ -1,5 +1,7 @@
 package com.github.topikachu.jenkins.concurrent.semaphore;
 
+import java.util.concurrent.ForkJoinPool;
+
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -57,5 +59,31 @@ public class SemaphoreTest {
         p.setDefinition(new CpsFlowDefinition(jenkinsFileContent, true));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
         r.assertLogContains("status=TIMEOUT", b);
+    }
+
+    @Test(timeout = 10000)
+    public void testTimeoutWithBody() throws Exception {
+        final String jenkinsFileContent = IOUtils.toString(SemaphoreTest.class.getResourceAsStream("Jenkinsfile.acquireTimeoutWithBody"));
+        final WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(jenkinsFileContent, true));
+        final WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        r.assertLogNotContains("body run", b);
+    }
+
+    @Test(timeout = 60000)
+    public void testHighConcurrency() throws Exception {
+        //Make sure we start much more steps than we've threads (needs timeout adjustment above if running with more than 100 cores!)
+        int parallelism = ForkJoinPool.commonPool().getParallelism() * 5;
+
+        final String jenkinsFileContent = IOUtils.toString(SemaphoreTest.class.getResourceAsStream("Jenkinsfile.highConcurrency"))
+            .replaceAll("\\$PARALLELISM\\$", Integer.toString(parallelism));
+        final WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(jenkinsFileContent, true));
+        final WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+
+        for (int i = 0; i < parallelism; i++)
+        {
+            r.assertLogContains("semaphore" + i + " body", b);
+        }
     }
 }

--- a/src/test/resources/com/github/topikachu/jenkins/concurrent/semaphore/Jenkinsfile.acquireTimeoutWithBody
+++ b/src/test/resources/com/github/topikachu/jenkins/concurrent/semaphore/Jenkinsfile.acquireTimeoutWithBody
@@ -1,0 +1,14 @@
+def semaphore = createSemaphore permit:1
+parallel(
+        semaphore1: {
+            acquireSemaphore semaphore
+            //without release
+        },
+        semaphore2: {
+            sleep 1
+            acquireSemaphore (semaphore:semaphore, timeout:2){
+                echo "body run"
+            }
+        }
+)
+

--- a/src/test/resources/com/github/topikachu/jenkins/concurrent/semaphore/Jenkinsfile.highConcurrency
+++ b/src/test/resources/com/github/topikachu/jenkins/concurrent/semaphore/Jenkinsfile.highConcurrency
@@ -1,0 +1,14 @@
+def semaphore = createSemaphore permit:1
+def s = [:]
+
+for(int i = 0; i < $PARALLELISM$; i ++) // must be much more than threads on the fork-join-pool
+{
+ def id="${i}"
+ s.put("semaphore" + id, { -> acquireSemaphore (semaphore){
+                                  sleep time:100,unit:"MILLISECONDS"
+                                  echo "semaphore" + id + " body"
+                              }
+                         })
+}
+
+parallel s


### PR DESCRIPTION
Fix #1: Due to the limited size of the ForkJoinThreadpool used by the plugin, there is a high risk of deadlocks / low throughput if many or all threads are waiting to acquire a semaphore, and none or just a few threads are available to actually trigger the custom code or release semaphores again.
Fix #2: The timeout handling for acquireSemaphore with body is broken: The body gets executed after a timeout and the (not acquired) semaphore gets released.